### PR TITLE
chore: replace CLAUDE.md files with unified AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,4 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+# dots
 
 ## What This Is
 
@@ -35,7 +33,7 @@ Entrypoint chain: `.zshenv` → sources `env/*.zsh` (vars, aliases, functions, b
 
 ### Qtile Wayland (`dot_config/qtile-wl/`)
 
-See `dot_config/qtile-wl/CLAUDE.md` for detailed architecture. Entry point: `config.py`. Modular Python config with JSON-driven settings in `json/`. Formatting: Black (line-length 98) + isort (profile "black").
+See `dot_config/qtile-wl/AGENTS.md` for detailed architecture. Entry point: `config.py`. Modular Python config with JSON-driven settings in `json/`. Formatting: Black (line-length 98) + isort (profile "black").
 
 ### Tmux (`dot_config/tmux/`)
 

--- a/dot_config/nvim/AGENTS.md
+++ b/dot_config/nvim/AGENTS.md
@@ -1,10 +1,8 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+# Neovim Config
 
 ## Overview
 
-This is a personal Neovim configuration built on [LazyVim](https://lazyvim.github.io/) (a Neovim distribution using lazy.nvim as its plugin manager). All configuration is written in Lua.
+Personal Neovim configuration built on [LazyVim](https://lazyvim.github.io/) (a Neovim distribution using lazy.nvim as its plugin manager). All configuration is written in Lua.
 
 ## Formatting
 
@@ -38,5 +36,5 @@ Lua files are formatted with **StyLua**: 2-space indentation, spaces (not tabs),
 - **Auto-save is active** with 1s debounce; the `u` → `2u` remap in rust/python compensates for auto-save creating extra undo states
 - **Python LSP**: Pyright (type checking off, diagnostics ignored) + Ruff (formatting/linting only, hover disabled)
 - **lspconfig.lua uses opts-only pattern** — no custom `config` function, lets LazyVim handle the config lifecycle
-- **Local plugin**: `vim-matlab` loaded from `~/src/mine/projects/nvim/plugins/vim-matlab`
+- **Local plugin**: `vim-matlab` loaded from `~/src/mine/system_and_config/editors/nvim/plugins/vim-matlab`
 - Custom plugins load eagerly by default (`lazy = false` in lazy.nvim defaults)

--- a/dot_config/qtile-wl/AGENTS.md
+++ b/dot_config/qtile-wl/AGENTS.md
@@ -1,6 +1,4 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+# Qtile Wayland Config
 
 ## What This Is
 
@@ -65,7 +63,7 @@ User-facing configuration lives in `json/` — edit these instead of Python when
 | `json/matches.json`      | App class → workspace group mapping                                  |
 | `json/themes.json`       | Available theme names                                                |
 
-`json/config.json` is loaded via `exec()` in `config.py`, so every key becomes a top-level Qtile variable.
+`json/config.json` is loaded by `config.py` at startup, so every key becomes a top-level Qtile variable.
 
 ### Themes
 
@@ -104,5 +102,5 @@ Split across `keys/`:
 - `psutil` — system stats widgets
 - `notify2` — desktop notifications
 - `json5` — JSON5 parsing for flexible config files
-- `jsonpickle` — group state serialization
+- `jsonpickle` — group state serialization (group state persistence across restarts)
 - `rofi` — launcher menus


### PR DESCRIPTION
Renames all three `CLAUDE.md` files (root, `dot_config/nvim/`, `dot_config/qtile-wl/`) to `AGENTS.md` for compatibility with multiple AI agents. Agent-specific boilerplate removed; content unchanged.